### PR TITLE
fix: change to default branch prefix so that renovate branches can be…

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,13 +7,13 @@
     "github>tx-pts-dai/renovate-config:group-github-actions-minor-patch",
     "github>tx-pts-dai/renovate-config:group-terraform-minor-patch"
   ],
-  "branchPrefix": "renovate_",
+  "branchPrefix": "renovate/",
   "timezone": "Europe/Zurich",
   "dependencyDashboardTitle": "Renovate Dashboard",
   "suppressNotifications": ["prIgnoreNotification"],
   "commitBodyTable": true,
   "rebaseWhen": "conflicted",
-  "platformCommit": true,
+  "platformCommit": "enabled",
   "reviewersFromCodeOwners": true,
   "prCreation": "immediate",
   "enabledManagers": ["dockerfile", "terraform", "github-actions", "circleci"]


### PR DESCRIPTION
… namespaced


Allows for using * in branch include and renovate branches will not be included. 