### PR TITLE
Disable renovate precommit hook minor patch

### DIFF
--- a/actions-org-migration.json
+++ b/actions-org-migration.json
@@ -3,8 +3,12 @@
   "packageRules": [
     {
       "description": "Replace `tx-pts-dai` with `DND-IT` in GitHub Actions.",
-      "matchDatasources": ["github-tags"],
-      "matchPackageNames": ["tx-pts-dai/github-workflows"],
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchPackageNames": [
+        "tx-pts-dai/github-workflows"
+      ],
       "replacementName": "DND-IT/github-workflows",
       "groupName": "Github Workflow Migration",
       "groupSlug": "github-workflow-migration"

--- a/default.json
+++ b/default.json
@@ -9,7 +9,8 @@
     "github>tx-pts-dai/renovate-config:group-pre-commit-minor-patch",
     "github>tx-pts-dai/renovate-config:group-kaas",
     "github>tx-pts-dai/renovate-config:custom-managers.json5",
-    "github>tx-pts-dai/renovate-config:actions-org-migration.json"
+    "github>tx-pts-dai/renovate-config:actions-org-migration.json",
+    "github>tx-pts-dai/renovate-config:manager-precommit.json"
   ],
   "branchPrefix": "renovate/",
   "timezone": "Europe/Zurich",
@@ -27,7 +28,6 @@
     "terraform",
     "github-actions",
     "custom.regex",
-    "pre-commit",
     "helm-values",
     "pip-requirements"
   ]

--- a/group-github-actions-minor-patch.json
+++ b/group-github-actions-minor-patch.json
@@ -2,12 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pinDigest"
+      ],
       "groupName": "github-actions minor / patch updates",
       "groupSlug": "github-actions-all-minor-patch"
     }
   ],
-  "enabledManagers": ["github-actions"]
-
+  "enabledManagers": [
+    "github-actions"
+  ]
 }

--- a/group-pre-commit-minor-patch.json
+++ b/group-pre-commit-minor-patch.json
@@ -2,11 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchManagers": ["pre-commit"],
-      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pinDigest"
+      ],
       "groupName": "pre-commit minor / patch updates",
       "groupSlug": "pre-commit-all-minor-patch"
     }
   ],
-  "enabledManagers": ["pre-commit"]
+  "enabledManagers": [
+    "pre-commit"
+  ]
 }

--- a/group-terraform-minor-patch.json
+++ b/group-terraform-minor-patch.json
@@ -2,11 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchManagers": ["terraform"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "groupName": "terraform minor / patch updates",
       "groupSlug": "terraform-all-minor-patch"
     }
   ],
-  "enabledManagers": ["terraform"]
+  "enabledManagers": [
+    "terraform"
+  ]
 }

--- a/manager-precommit.json
+++ b/manager-precommit.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "matchPackageNames": [
+        "renovatebot/pre-commit-hooks"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "enabled": false
+    }
+  ],
+  "enabledManagers": [
+    "pre-commit"
+  ]
+}


### PR DESCRIPTION
renovate precommit will only update major versions - it was too noisy 