### PR TITLE
feat: enable argocd manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -32,7 +32,8 @@
     "helm-values",
     "helmv3",
     "pip-requirements",
-    "kustomize"
+    "kustomize",
+    "argocd"
   ],
   "labels": ["renovate"],
   "packageRules": [
@@ -59,6 +60,10 @@
     {
       "matchManagers": ["kustomize"],
       "addLabels": ["kustomize"]
+    },
+    {
+      "matchManagers": ["argocd"],
+      "addLabels": ["argocd"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Enable the `argocd` Renovate manager to scan ArgoCD Application manifests for dependency updates
- Add `argocd` label to PRs created by the ArgoCD manager

## Test plan
- [ ] Verify Renovate picks up ArgoCD Application manifests in consuming repos
- [ ] Verify PRs from the ArgoCD manager are labeled with `argocd`