### PR TITLE
feat: track DND-IT/github-workflows reusable workflows per-workflow tag

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,6 +9,7 @@
     "github>tx-pts-dai/renovate-config:group-kaas",
     "github>tx-pts-dai/renovate-config:custom-managers.json5",
     "github>tx-pts-dai/renovate-config:actions-org-migration.json",
+    "github>tx-pts-dai/renovate-config:github-workflows-per-workflow-tags.json5",
     "github>tx-pts-dai/renovate-config:exclude.json"
   ],
   "branchPrefix": "renovate/",

--- a/github-workflows-per-workflow-tags.json5
+++ b/github-workflows-per-workflow-tags.json5
@@ -35,7 +35,14 @@
       matchDatasources: ['github-tags'],
       matchPackageNames: ['DND-IT/github-workflows'],
       matchCurrentValue: '!/^[\\w-]+-v\\d/',
-      replacementName: 'DND-IT/github-workflows',
+      // replacementNameTemplate is intentionally the same as depName: we aren't renaming
+      // anything, only forcing a version jump that plain versioning wouldn't allow. Setting
+      // replacementName to a *different* value (e.g. the bare packageName) makes Renovate's
+      // auto-replace logic search for that literal string in the file to rename it — since
+      // our depName is synthetic (never appears verbatim in file content), that search
+      // always fails and the update silently drops (upstream renovatebot/renovate quirk in
+      // doAutoReplace's firstIndexOf treating "not found" (-1) as the smallest index).
+      replacementNameTemplate: '{{{depName}}}',
       replacementVersionTemplate: "{{lookup (split depName '/') 2}}-v0.1.0",
       groupName: 'Github Workflow per-workflow tag migration',
       groupSlug: 'github-workflow-tag-migration',

--- a/github-workflows-per-workflow-tags.json5
+++ b/github-workflows-per-workflow-tags.json5
@@ -1,0 +1,53 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  // DND-IT/github-workflows now cuts a release tag per reusable workflow
+  // (e.g. tf-plan-v0.1.0, tf-apply-v0.1.0) in addition to its umbrella tag
+  // (e.g. v4.1.2). The built-in github-actions manager can't tell one
+  // workflow file apart from another within the same repo (depName is
+  // always just "owner/repo"), so a custom manager captures the workflow
+  // name into a synthetic depName to track each one independently.
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Track DND-IT/github-workflows reusable workflow calls per-workflow instead of via the shared umbrella tag.',
+      fileMatch: [
+        '^\\.github/workflows/.*\\.ya?ml$',
+      ],
+      matchStrings: [
+        'uses:\\s*DND-IT/github-workflows/\\.github/workflows/(?<workflow>[\\w-]+)\\.ya?ml@(?<currentDigest>[0-9a-f]{40})\\s*#\\s*(?<currentValue>\\S+)',
+      ],
+      depNameTemplate: 'DND-IT/github-workflows/{{{workflow}}}',
+      packageNameTemplate: 'DND-IT/github-workflows',
+      datasourceTemplate: 'github-tags',
+    },
+  ],
+  packageRules: [
+    {
+      description: 'The custom manager above owns DND-IT/github-workflows reusable-workflow pins; stop the built-in github-actions manager from also proposing umbrella-tag updates for them.',
+      matchManagers: ['github-actions'],
+      matchDatasources: ['github-tags'],
+      matchPackageNames: ['DND-IT/github-workflows'],
+      enabled: false,
+    },
+    {
+      description: 'One-time migration from the shared umbrella tag to this call\'s own per-workflow release tag.',
+      matchManagers: ['custom.regex'],
+      matchDatasources: ['github-tags'],
+      matchPackageNames: ['DND-IT/github-workflows'],
+      matchCurrentValue: '!/^[\\w-]+-v\\d/',
+      replacementName: 'DND-IT/github-workflows',
+      replacementVersionTemplate: "{{lookup (split depName '/') 2}}-v0.1.0",
+      groupName: 'Github Workflow per-workflow tag migration',
+      groupSlug: 'github-workflow-tag-migration',
+    },
+    {
+      description: 'Once migrated, keep tracking updates within this call\'s own workflow release lineage instead of another workflow\'s tags.',
+      matchManagers: ['custom.regex'],
+      matchDatasources: ['github-tags'],
+      matchPackageNames: ['DND-IT/github-workflows'],
+      matchCurrentValue: '/^[\\w-]+-v\\d/',
+      versionCompatibility: '^(?<compatibility>.*)-v(?<version>.*)$',
+      versioning: 'semver',
+    },
+  ],
+}

--- a/github-workflows-per-workflow-tags.json5
+++ b/github-workflows-per-workflow-tags.json5
@@ -41,13 +41,22 @@
       groupSlug: 'github-workflow-tag-migration',
     },
     {
+      description: 'Suppress the regular major/minor/patch bump that Renovate computes alongside the replacement above (both target the same currentValue) — only the migration replacement should be proposed until this call is on its per-workflow tag.',
+      matchManagers: ['custom.regex'],
+      matchDatasources: ['github-tags'],
+      matchPackageNames: ['DND-IT/github-workflows'],
+      matchCurrentValue: '!/^[\\w-]+-v\\d/',
+      matchUpdateTypes: ['major', 'minor', 'patch', 'digest', 'pin', 'pinDigest', 'bump', 'rollback'],
+      enabled: false,
+    },
+    {
       description: 'docker-build-push-ecr\'s per-workflow tagged releases require the caller workflow to grant additional permissions; flag this in the migration PR.',
       matchManagers: ['custom.regex'],
       matchDatasources: ['github-tags'],
       matchDepNames: ['DND-IT/github-workflows/docker-build-push-ecr'],
       matchCurrentValue: '!/^[\\w-]+-v\\d/',
       prBodyNotes: [
-        '⚠️ **Breaking change**: `docker-build-push-ecr` now requires the caller workflow to grant additional permissions. Add the following to the calling job (or workflow):\n\n```yaml\npermissions:\n  id-token: write\n  contents: read\n  packages: read # allow access to private NPM packages hosted on GitHub\n```',
+        '⚠️ **Breaking change**: add `packages: read` to this workflow\'s `permissions:` block (required by `docker-build-push-ecr` to access private NPM packages hosted on GitHub).',
       ],
     },
     {

--- a/github-workflows-per-workflow-tags.json5
+++ b/github-workflows-per-workflow-tags.json5
@@ -44,6 +44,10 @@
       // doAutoReplace's firstIndexOf treating "not found" (-1) as the smallest index).
       replacementNameTemplate: '{{{depName}}}',
       replacementVersionTemplate: "{{lookup (split depName '/') 2}}-v0.1.0",
+      // Since replacementNameTemplate equals depName, the default commit/PR title would read
+      // as "replace dependency X with X" — override the "with ..." part to say what's
+      // actually happening instead.
+      commitMessageExtra: 'with its per-workflow release tag ({{{newValue}}})',
       groupName: 'Github Workflow per-workflow tag migration',
       groupSlug: 'github-workflow-tag-migration',
     },

--- a/github-workflows-per-workflow-tags.json5
+++ b/github-workflows-per-workflow-tags.json5
@@ -41,6 +41,16 @@
       groupSlug: 'github-workflow-tag-migration',
     },
     {
+      description: 'docker-build-push-ecr\'s per-workflow tagged releases require the caller workflow to grant additional permissions; flag this in the migration PR.',
+      matchManagers: ['custom.regex'],
+      matchDatasources: ['github-tags'],
+      matchDepNames: ['DND-IT/github-workflows/docker-build-push-ecr'],
+      matchCurrentValue: '!/^[\\w-]+-v\\d/',
+      prBodyNotes: [
+        '⚠️ **Breaking change**: `docker-build-push-ecr` now requires the caller workflow to grant additional permissions. Add the following to the calling job (or workflow):\n\n```yaml\npermissions:\n  id-token: write\n  contents: read\n  packages: read # allow access to private NPM packages hosted on GitHub\n```',
+      ],
+    },
+    {
       description: 'Once migrated, keep tracking updates within this call\'s own workflow release lineage instead of another workflow\'s tags.',
       matchManagers: ['custom.regex'],
       matchDatasources: ['github-tags'],


### PR DESCRIPTION
## Summary

`DND-IT/github-workflows` now cuts a release tag per reusable workflow (e.g. `tf-plan-v0.1.0`, `tf-apply-v0.1.0`) alongside its umbrella tag (e.g. `v4.1.2`), so a repo pinning to `tf-plan-v0.1.0` only gets bumped when `tf-plan.yaml` itself changes, instead of on every unrelated change across the whole `github-workflows` repo.

Renovate's built-in `github-actions` manager can't take advantage of this on its own: for a reusable workflow call (`uses: owner/repo/.github/workflows/x.yaml@ref`), its `depName` collapses to just `owner/repo` — the workflow file path isn't part of the dependency identity. That's confirmed against Renovate's extractor source, and is why the existing `actions-org-migration.json` pattern (a plain `packageRules` replacement) doesn't transfer to this case — it can't tell `tf-plan.yaml` apart from `tf-apply.yaml` in the same file.

`github-workflows-per-workflow-tags.json5` adds:
- A **custom regex manager** that captures the workflow name out of each `uses:` line and synthesizes a per-workflow `depName` (e.g. `DND-IT/github-workflows/tf-plan`), so each reusable workflow call is tracked as its own dependency.
- A rule disabling the built-in `github-actions` manager for `DND-IT/github-workflows`, so it stops proposing competing umbrella-tag updates for the same lines.
- A **one-time migration rule**: any call still pinned to the old umbrella tag gets a PR replacing it with its own `<workflow>-v0.1.0` tag.
- An **ongoing rule**: once pinned to `<workflow>-vX.Y.Z`, `versionCompatibility` keeps future updates scoped to that workflow's own release lineage.

Once merged, every repo extending this shared config (~39 repos currently reference `DND-IT/github-workflows` reusable workflows) will get a migration PR from Renovate on its next run — no per-repo script needed.

## Test plan
- [x] Verified against Renovate's `github-actions` extractor source that `depName` is repo-scoped, confirming why a custom manager (not a plain packageRules replacement) is required.
- [x] Ran `renovate-config-validator` (v39.264.0, matching the pinned pre-commit hook version) against every config file in the repo — this file and the `default.json` change validate cleanly (two unrelated pre-existing errors on `main` are filed separately: #38, #39).
- [x] Unit-tested the regex extraction and `depName`-splitting logic in isolation against real sample `uses:` lines (including the ones from `DND-IT/fission-backstage#121`) — both the workflow-name capture and the `{{lookup (split depName '/') 2}}-v0.1.0` template resolve correctly.
- [ ] Not yet verified end-to-end against a live Renovate run (e.g. Dependency Dashboard on a real consuming repo) — recommend watching the first migration PR it produces (fission-backstage is a good candidate since PR #121 there is being held pending this) before assuming it's fully correct in practice.