### PR TITLE
fix: rename pip-requirements to pip_requirements in enabledManagers

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,7 +29,7 @@
     "custom.regex",
     "helm-values",
     "helmv3",
-    "pip-requirements",
+    "pip_requirements",
     "kustomize",
     "argocd",
     "pre-commit"
@@ -53,7 +53,7 @@
       "addLabels": ["helm"]
     },
     {
-      "matchManagers": ["pip-requirements"],
+      "matchManagers": ["pip_requirements"],
       "addLabels": ["python"]
     },
     {


### PR DESCRIPTION
# fix: rename pip-requirements to pip_requirements in enabledManagers

## Summary
The enabledManagers list incorrectly used "pip-requirements" instead of the correct manager name "pip_requirements". This caused Renovate to ignore pip requirements because the manager name is wrong. This change renames the manager to the correct identifier in both enabledManagers and the corresponding packageRules entry.

Fixes #38

## Changes
- Renamed pip-requirements to pip_requirements in enabledManagers array
- Renamed pip-requirements to pip_requirements in packageRules matchManagers for python labeling

## Testing
- Verified JSON syntax is valid using python -m json.tool
- Confirmed no other occurrences of pip-requirements exist in the repository

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
