### PR TITLE
feat: match DND-IT/github-workflows org case-insensitively

### DIFF
--- a/github-workflows-per-workflow-tags.json5
+++ b/github-workflows-per-workflow-tags.json5
@@ -14,11 +14,17 @@
         '^\\.github/workflows/.*\\.ya?ml$',
       ],
       matchStrings: [
-        'uses:\\s*DND-IT/github-workflows/\\.github/workflows/(?<workflow>[\\w-]+)\\.ya?ml@(?<currentDigest>[0-9a-f]{40})\\s*#\\s*(?<currentValue>\\S+)',
+        // The org is matched case-insensitively (GitHub owner names are), so both
+        // `DND-IT/...` and `dnd-it/...` are picked up. The `ext` group preserves the
+        // caller's `.yml`/`.yaml` choice when the line is rewritten.
+        'uses:\\s*[Dd][Nn][Dd]-[Ii][Tt]/github-workflows/\\.github/workflows/(?<workflow>[\\w-]+)\\.(?<ext>ya?ml)@(?<currentDigest>[0-9a-f]{40})\\s*#\\s*(?<currentValue>\\S+)',
       ],
       depNameTemplate: 'DND-IT/github-workflows/{{{workflow}}}',
       packageNameTemplate: 'DND-IT/github-workflows',
       datasourceTemplate: 'github-tags',
+      // Rebuild the whole line on update rather than substituting values in place, so a
+      // lowercase `dnd-it/` gets normalized to the canonical `DND-IT/` at the same time.
+      autoReplaceStringTemplate: 'uses: DND-IT/github-workflows/.github/workflows/{{{workflow}}}.{{{ext}}}@{{{newDigest}}} # {{{newValue}}}',
     },
   ],
   packageRules: [
@@ -26,7 +32,9 @@
       description: 'The custom manager above owns DND-IT/github-workflows reusable-workflow pins; stop the built-in github-actions manager from also proposing umbrella-tag updates for them.',
       matchManagers: ['github-actions'],
       matchDatasources: ['github-tags'],
-      matchPackageNames: ['DND-IT/github-workflows'],
+      // Regex + `i` flag: the built-in manager reports the package name with the file's
+      // original casing, so match `dnd-it/github-workflows` too.
+      matchPackageNames: ['/^dnd-it\\/github-workflows$/i'],
       enabled: false,
     },
     {

--- a/tests/custom_managers/github_workflows/README.md
+++ b/tests/custom_managers/github_workflows/README.md
@@ -1,0 +1,24 @@
+# Per-workflow tracking of DND-IT/github-workflows
+
+Tests for the custom manager in
+[`github-workflows-per-workflow-tags.json5`](../../../github-workflows-per-workflow-tags.json5),
+which tracks each `DND-IT/github-workflows` reusable workflow against its own
+per-workflow release tag instead of the repo's shared umbrella tag.
+
+`test.js` reads the regex and templates directly from the config and asserts:
+
+- the `uses:` matcher accepts the org in any casing (`DND-IT`, `dnd-it`, mixed)
+  and captures the workflow name, file extension, digest and tag;
+- only digest-pinned references (`@<sha> # <tag>`) are tracked — a plain
+  `@v3` tag ref is ignored;
+- `autoReplaceStringTemplate` rewrites a lowercase `dnd-it/` reference to the
+  canonical `DND-IT/` on update, preserving the caller's `.yml`/`.yaml` choice;
+- the rule that disables the built-in `github-actions` manager matches the
+  package name in either casing without catching the synthetic sub-workflow
+  names owned by the custom manager.
+
+Run:
+
+```sh
+node tests/custom_managers/github_workflows/test.js
+```

--- a/tests/custom_managers/github_workflows/test.js
+++ b/tests/custom_managers/github_workflows/test.js
@@ -1,0 +1,152 @@
+// Regression tests for the DND-IT/github-workflows custom manager.
+//
+// Run with: node tests/custom_managers/github_workflows/test.js
+// Exits non-zero on the first failed assertion.
+//
+// The regex and templates under test are read straight out of
+// github-workflows-per-workflow-tags.json5 so the tests exercise the real
+// config and can't silently drift from it.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const configPath = path.resolve(
+  __dirname,
+  '../../../github-workflows-per-workflow-tags.json5',
+);
+const config = fs.readFileSync(configPath, 'utf8');
+
+// Pull the first single-quoted literal off the config line matching `predicate`,
+// then undo JSON5's backslash doubling so we get the value Renovate actually uses.
+function quotedOn(predicate) {
+  const line = config.split('\n').find((l) => predicate(l.trim()));
+  assert.ok(line, `no config line matched ${predicate}`);
+  const literal = line.match(/'([^']*)'/);
+  assert.ok(literal, `no single-quoted value on line: ${line.trim()}`);
+  return literal[1].replace(/\\\\/g, '\\');
+}
+
+const matchPattern = new RegExp(quotedOn((l) => l.startsWith("'uses:")));
+const autoReplaceTpl = quotedOn((l) =>
+  l.startsWith('autoReplaceStringTemplate:'),
+);
+const packageNameRule = quotedOn((l) => l.startsWith("matchPackageNames: ['/"));
+
+// Minimal stand-in for Renovate's triple-brace template rendering. The template
+// only uses `{{{var}}}` substitutions, so this is faithful for our purposes.
+function render(template, vars) {
+  return template.replace(/\{\{\{(\w+)\}\}\}/g, (_, key) => {
+    assert.ok(key in vars, `template referenced unknown var {{{${key}}}}`);
+    return vars[key];
+  });
+}
+
+// Turn Renovate's `/pattern/flags` string form into a RegExp.
+function renovateRegex(value) {
+  const parsed = value.match(/^\/(.*)\/([a-z]*)$/);
+  assert.ok(parsed, `not a /regex/flags value: ${value}`);
+  return new RegExp(parsed[1], parsed[2]);
+}
+
+const DIGEST = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'; // 40 hex chars
+const NEW_DIGEST = '99887766554433221100ffeeddccbbaa00112233';
+
+let failures = 0;
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`  FAIL ${name}`);
+    console.error(`       ${err.message}`);
+  }
+}
+
+console.log('matchStrings pattern:');
+
+check('matches canonical uppercase DND-IT', () => {
+  const line = `      uses: DND-IT/github-workflows/.github/workflows/tf-plan.yaml@${DIGEST} # v4.1.2`;
+  const m = matchPattern.exec(line);
+  assert.ok(m, 'expected a match');
+  assert.equal(m.groups.workflow, 'tf-plan');
+  assert.equal(m.groups.ext, 'yaml');
+  assert.equal(m.groups.currentDigest, DIGEST);
+  assert.equal(m.groups.currentValue, 'v4.1.2');
+});
+
+check('matches lowercase dnd-it', () => {
+  const line = `      uses: dnd-it/github-workflows/.github/workflows/gitops-image-tag.yaml@${DIGEST} # v3`;
+  const m = matchPattern.exec(line);
+  assert.ok(m, 'expected lowercase org to match');
+  assert.equal(m.groups.workflow, 'gitops-image-tag');
+  assert.equal(m.groups.currentValue, 'v3');
+});
+
+check('matches mixed-case org and preserves .yml extension', () => {
+  const line = `      uses: Dnd-It/github-workflows/.github/workflows/docker-build-push-ecr.yml@${DIGEST} # v4`;
+  const m = matchPattern.exec(line);
+  assert.ok(m, 'expected mixed-case org to match');
+  assert.equal(m.groups.ext, 'yml');
+  assert.equal(m.groups.workflow, 'docker-build-push-ecr');
+});
+
+check('ignores a non-DND-IT action', () => {
+  const line = `      uses: actions/checkout@${DIGEST} # v4`;
+  assert.equal(matchPattern.exec(line), null);
+});
+
+check('ignores an unpinned tag ref (no digest, no comment)', () => {
+  // The original example: this manager only tracks digest-pinned lines.
+  const line = '      uses: dnd-it/github-workflows/.github/workflows/gitops-image-tag.yaml@v3';
+  assert.equal(matchPattern.exec(line), null);
+});
+
+console.log('autoReplaceStringTemplate (casing normalization):');
+
+check('rewrites a lowercase line to canonical DND-IT', () => {
+  const line = `      uses: dnd-it/github-workflows/.github/workflows/gitops-image-tag.yaml@${DIGEST} # v3`;
+  const m = matchPattern.exec(line);
+  const rewritten = render(autoReplaceTpl, {
+    workflow: m.groups.workflow,
+    ext: m.groups.ext,
+    newDigest: NEW_DIGEST,
+    newValue: 'gitops-image-tag-v0.1.0',
+  });
+  assert.equal(
+    rewritten,
+    `uses: DND-IT/github-workflows/.github/workflows/gitops-image-tag.yaml@${NEW_DIGEST} # gitops-image-tag-v0.1.0`,
+  );
+  assert.ok(!rewritten.includes('dnd-it'), 'lowercase org should be gone');
+});
+
+check('preserves .yml extension when rewriting', () => {
+  const line = `      uses: dnd-it/github-workflows/.github/workflows/tf-apply.yml@${DIGEST} # v4`;
+  const m = matchPattern.exec(line);
+  const rewritten = render(autoReplaceTpl, {
+    workflow: m.groups.workflow,
+    ext: m.groups.ext,
+    newDigest: NEW_DIGEST,
+    newValue: 'tf-apply-v0.1.0',
+  });
+  assert.ok(rewritten.includes('/tf-apply.yml@'), 'expected .yml to survive');
+});
+
+console.log('github-actions disable rule (matchPackageNames):');
+
+check('disable rule matches both casings but not sub-workflows', () => {
+  const re = renovateRegex(packageNameRule);
+  assert.ok(re.test('DND-IT/github-workflows'), 'should match uppercase');
+  assert.ok(re.test('dnd-it/github-workflows'), 'should match lowercase');
+  assert.ok(
+    !re.test('DND-IT/github-workflows/tf-plan'),
+    'should not match a synthetic sub-workflow name',
+  );
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll tests passed');


### PR DESCRIPTION
## What

Follow-up to #40. The per-workflow custom manager only matched the canonical uppercase `DND-IT` org, so `uses:` lines written with a lowercase `dnd-it/github-workflows` were silently skipped.

Two problems that fixes:
1. The regex matcher missed the workflow call entirely — no per-workflow tracking / migration PR.
2. The rule that disables the built-in `github-actions` manager matched `DND-IT/github-workflows` case-sensitively, so for a lowercase reference the built-in manager was *not* disabled and would raise duplicate umbrella-tag PRs.

## Changes

- **Case-insensitive org match** — `[Dd][Nn][Dd]-[Ii][Tt]` (character classes rather than an inline flag, so it works regardless of whether Renovate compiles the matchString with re2 or native JS regex).
- **Normalize lowercase → uppercase on update** — added `autoReplaceStringTemplate` that rebuilds the line with the canonical `DND-IT/` prefix. Added an `(?<ext>ya?ml)` capture group so the caller's original `.yml`/`.yaml` extension is preserved when the line is rewritten.
- **Case-insensitive disable rule** — `matchPackageNames: ['/^dnd-it\/github-workflows$/i']`.

The other `custom.regex` rules keep `matchPackageNames: ['DND-IT/github-workflows']` on purpose — they match the custom manager's own output, and `packageNameTemplate` is hardcoded uppercase.

## Tests

Added `tests/custom_managers/github_workflows/` (same layout as the existing `terraform_helm` test). `test.js` reads the regex and templates straight out of the config file so they can't drift, and asserts:

- the matcher accepts `DND-IT` / `dnd-it` / mixed case and captures workflow, ext, digest, tag;
- only digest-pinned refs are tracked — a plain `@v3` tag ref is ignored;
- `autoReplaceStringTemplate` rewrites lowercase → `DND-IT`, preserving `.yml`/`.yaml`;
- the disable rule matches both casings but not the synthetic sub-workflow names.

Run: `node tests/custom_managers/github_workflows/test.js` (8 assertions, all pass).

## Note on caveat

Casing is only normalized when an update PR is raised (migration bump, digest update, etc.) — Renovate has no cosmetic-only reformat pass. Anything not yet on a per-workflow tag gets normalized by its migration PR.